### PR TITLE
correct handle being null on meteor 1.1 issue

### DIFF
--- a/lib.coffee
+++ b/lib.coffee
@@ -31,7 +31,7 @@ class ComputedField
         # XXX COMPAT WITH METEOR 1.1.0
         originalStop = handle.stop
         handle.stop = ->
-          originalStop.call handle
+          originalStop.call handle if handle ?
           handle = null
 
     startAutorun()


### PR DESCRIPTION
Hi  @mitar  thanks again for your suggestion to use this package. I think its very valuable and i am using it very frequently now. I am using a nested Tracker and field computations inside to handle some complex situations and it works very well but i am getting a strange error where the handle in the onStop callback seems to be null when calling the originalStop function. I just added a check into the line. I dont know the consequenses. Would be great to hear something about this.

Cheers
Med
